### PR TITLE
Fix stack-buffer-overflow in ext4_dir_get_csum

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ cd ../
 sudo umount tmp
 
 ## run
-cargo run LOG=trace
+cargo run --release LOG=trace
 
 ## write check
 sudo mount ./ex4.img ./tmp/


### PR DESCRIPTION
See #10 for details.
This also changes the test in run.sh to run in release mode.