### PR TITLE
fix: Support filesystems with single block groups in write_at

### DIFF
--- a/src/ext4_impls/file.rs
+++ b/src/ext4_impls/file.rs
@@ -315,8 +315,7 @@ impl Ext4 {
         let mut new_blocks = 0;
 
         // Start bgid for block allocation
-        let block_group_count = self.super_block.block_group_count();
-        let mut start_bgid = if block_group_count > 1 { 1 } else { 0 };
+        let mut start_bgid = 0;
 
         // Pre-allocate blocks if needed
         let blocks_to_allocate = if iblk_idx >= ifile_blocks as usize {

--- a/src/ext4_impls/file.rs
+++ b/src/ext4_impls/file.rs
@@ -315,7 +315,8 @@ impl Ext4 {
         let mut new_blocks = 0;
 
         // Start bgid for block allocation
-        let mut start_bgid = 1;
+        let block_group_count = self.super_block.block_group_count();
+        let mut start_bgid = if block_group_count > 1 { 1 } else { 0 };
 
         // Pre-allocate blocks if needed
         let blocks_to_allocate = if iblk_idx >= ifile_blocks as usize {


### PR DESCRIPTION
Hey there, I got a couple of warnings in a project I'm currently working on.

The `write_at` function always assumes a starting offset of `1` for the block allocation. In very small filesystems (like my testing QEMU setup) this fails because we only have one block group -> can't start allocating at `1`.

It's not a big issue, I just wanted to make the warnings about `invalid start_bgid, resetting to 0` go away.

Let me know if that works for you or if there's anything I missed, cheers!